### PR TITLE
マンダラチャートを9x9グリッドに拡張し、OpenAI統合を実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
-  "name": "vite-react-typescript-starter",
+  "name": "mirai-node",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "vite-react-typescript-starter",
+      "name": "mirai-node",
       "version": "0.0.0",
       "dependencies": {
         "d3": "^7.8.5",
         "lucide-react": "^0.344.0",
+        "openai": "^4.76.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "reactflow": "^11.10.4",
@@ -1583,6 +1584,23 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
     },
+    "node_modules/@types/node": {
+      "version": "18.19.68",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.68.tgz",
+      "integrity": "sha512-QGtpFH1vB99ZmTa63K4/FU8twThj4fuVSBkGddTp7uIL/cuoLWIUSL2RcOaigBhfR+hg5pgGkBnkoOxrTVBMKw==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.13",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.13.tgz",
@@ -1857,6 +1875,17 @@
         "vite": "^4.2.0 || ^5.0.0"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.12.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
@@ -1876,6 +1905,17 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.5.0.tgz",
+      "integrity": "sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/ajv": {
@@ -1948,6 +1988,11 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/autoprefixer": {
       "version": "10.4.20",
@@ -2165,6 +2210,17 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/commander": {
       "version": "4.1.1",
@@ -2628,6 +2684,14 @@
         "robust-predicates": "^3.0.2"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
@@ -2964,6 +3028,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3092,6 +3164,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A=="
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
       }
     },
     "node_modules/fraction.js": {
@@ -3232,6 +3334,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "dependencies": {
+        "ms": "^2.0.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -3550,6 +3660,25 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -3574,8 +3703,7 @@
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/mz": {
       "version": "2.7.0",
@@ -3611,6 +3739,43 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.18",
@@ -3652,6 +3817,31 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/openai": {
+      "version": "4.76.1",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.76.1.tgz",
+      "integrity": "sha512-ci63/WFEMd6QjjEVeH0pV7hnFS6CCqhgJydSti4Aak/8uo2SpgzKjteUDaY+OkwziVj11mi6j+0mRUIiGKUzWw==",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      },
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/optionator": {
@@ -4471,6 +4661,11 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "node_modules/ts-api-utils": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
@@ -4536,6 +4731,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.1",
@@ -4647,6 +4847,28 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "d3": "^7.8.5",
     "lucide-react": "^0.344.0",
+    "openai": "^4.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "reactflow": "^11.10.4",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,52 @@
-import { MandalaTest } from './components/MandalaTest';
+import  { useEffect } from 'react';
+import { Flow } from './components/Flow';
+import { InputForm } from './components/InputForm';
+import { MandalaChart } from './components/MandalaChart';
+import { Sidebar } from './components/Sidebar';
+import { useFlowStore } from './store/useFlowStore';
+import { useMandalaStore } from './store/useMandalaStore';
+import { ViewMode } from './types';
 
 function App() {
+  const addNode = useFlowStore((state) => state.addNode);
+  const viewMode = useFlowStore((state) => state.viewMode);
+  const setViewMode = useFlowStore((state) => state.setViewMode);
+  const initializeFlow = useFlowStore((state) => state.initializeFlow);
+  const initializeMandala = useMandalaStore((state) => state.initializeMandala);
+
+  // URLクエリパラメータの監視
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const mode = params.get('mode') as ViewMode;
+    if (mode && (mode === 'neural' || mode === 'mandala')) {
+      setViewMode(mode);
+    }
+
+    // ブラウザの戻る/進むボタンの監視
+    const handlePopState = () => {
+      const params = new URLSearchParams(window.location.search);
+      const mode = params.get('mode') as ViewMode;
+      if (mode && (mode === 'neural' || mode === 'mandala')) {
+        setViewMode(mode);
+      }
+    };
+
+    window.addEventListener('popstate', handlePopState);
+    return () => window.removeEventListener('popstate', handlePopState);
+  }, [setViewMode]);
+
+  useEffect(() => {
+    initializeFlow();
+    initializeMandala();
+  }, [initializeFlow, initializeMandala]);
+
   return (
     <div className="flex w-full h-screen bg-black">
-      <MandalaTest />
+      <Sidebar />
+      <div className="flex-1 relative">
+        {viewMode === 'neural' ? <Flow /> : <MandalaChart />}
+        <InputForm onSubmit={addNode} />
+      </div>
     </div>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,52 +1,9 @@
-import  { useEffect } from 'react';
-import { Flow } from './components/Flow';
-import { InputForm } from './components/InputForm';
-import { MandalaChart } from './components/MandalaChart';
-import { Sidebar } from './components/Sidebar';
-import { useFlowStore } from './store/useFlowStore';
-import { useMandalaStore } from './store/useMandalaStore';
-import { ViewMode } from './types';
+import { MandalaTest } from './components/MandalaTest';
 
 function App() {
-  const addNode = useFlowStore((state) => state.addNode);
-  const viewMode = useFlowStore((state) => state.viewMode);
-  const setViewMode = useFlowStore((state) => state.setViewMode);
-  const initializeFlow = useFlowStore((state) => state.initializeFlow);
-  const initializeMandala = useMandalaStore((state) => state.initializeMandala);
-
-  // URLクエリパラメータの監視
-  useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
-    const mode = params.get('mode') as ViewMode;
-    if (mode && (mode === 'neural' || mode === 'mandala')) {
-      setViewMode(mode);
-    }
-
-    // ブラウザの戻る/進むボタンの監視
-    const handlePopState = () => {
-      const params = new URLSearchParams(window.location.search);
-      const mode = params.get('mode') as ViewMode;
-      if (mode && (mode === 'neural' || mode === 'mandala')) {
-        setViewMode(mode);
-      }
-    };
-
-    window.addEventListener('popstate', handlePopState);
-    return () => window.removeEventListener('popstate', handlePopState);
-  }, [setViewMode]);
-
-  useEffect(() => {
-    initializeFlow();
-    initializeMandala();
-  }, [initializeFlow, initializeMandala]);
-
   return (
     <div className="flex w-full h-screen bg-black">
-      <Sidebar />
-      <div className="flex-1 relative">
-        {viewMode === 'neural' ? <Flow /> : <MandalaChart />}
-        <InputForm onSubmit={addNode} />
-      </div>
+      <MandalaTest />
     </div>
   );
 }

--- a/src/components/MandalaChart.tsx
+++ b/src/components/MandalaChart.tsx
@@ -1,23 +1,20 @@
 import React, { useRef, useEffect, useState, useMemo } from 'react';
 import { MandalaNode } from '../types';
 import { useMandalaStore } from '../store/useMandalaStore';
-import { generateMandalaContent } from '../utils/mandalaOpenai';
 
 // 定数定義
-const CELL_SIZE = 60; // 1マスのサイズを小さく調整
-const GRID_SIZE = CELL_SIZE * 3; // 3x3グリッド全体のサイズ
+const CELL_SIZE = 90;
+const GRID_SIZE = CELL_SIZE * 9;
 
 export const MandalaChart: React.FC = () => {
   const mandalaNodes = useMandalaStore((state) => state.mandalaNodes);
   const currentMandalaId = useMandalaStore((state) => state.currentMandalaId);
   const setCurrentMandalaId = useMandalaStore((state) => state.setCurrentMandalaId);
+  const generateMandalaChart = useMandalaStore((state) => state.generateMandalaChart);
   const containerRef = useRef<HTMLDivElement>(null);
   const [isLoading, setIsLoading] = useState(false);
-  const addNode = useMandalaStore((state) => state.addNode);
-  const updateNode = useMandalaStore((state) => state.updateNode);
   const [newTopic, setNewTopic] = useState('');
 
-  // 最初のマンダラチャートが表示されたときに自動的に選択
   useEffect(() => {
     if (mandalaNodes.length > 0 && !currentMandalaId) {
       const firstCenterNode = mandalaNodes.find(node => node.isCenter);
@@ -27,79 +24,44 @@ export const MandalaChart: React.FC = () => {
     }
   }, [mandalaNodes, currentMandalaId, setCurrentMandalaId]);
 
-  const currentMandala = mandalaNodes.find(node => 
-    node.isCenter && node.id === currentMandalaId
+  const currentMandala = useMemo(() => 
+    mandalaNodes.find(node => node.id === currentMandalaId),
+    [mandalaNodes, currentMandalaId]
   );
 
-  const handleGenerateTopics = async () => {
-    if (!currentMandala) return;
+  // relatedNodesの取得を修正
+  const relatedNodes = useMemo(() => {
+    if (!currentMandala) return [];
     
-    setIsLoading(true);
-    try {
-      const topics = await generateMandalaContent(currentMandala.label);
-      
-      // 既存の子ノードを更新または新規作成
-      topics.forEach((topic: string, index: number) => {
-        const existingChild = currentMandala.children?.[index];
-        if (existingChild) {
-          // 既存のノードを更新
-          updateNode({
-            ...existingChild,
-            label: topic
-          });
-        } else {
-          // 新規ノードを作成
-          addNode({
-            id: `${currentMandala.id}-${index}`,
-            label: topic,
-            parentId: currentMandala.id,
-            isCenter: false,
-            children: [],
-            position: { x: 0, y: 0 }
-          });
-        }
-      });
-    } catch (error) {
-      console.error('Failed to generate topics:', error);
-    } finally {
-      setIsLoading(false);
-    }
-  };
+    // 中心ノード
+    const centerNode = currentMandala;
+    
+    // 中心ノードに紐づく主要カテゴリーノード(8つ)
+    const mainNodes = mandalaNodes.filter(node => node.parentId === centerNode.id);
+    
+    // 9ノードを適切な順序で配置
+    const positionedNodes = [
+      mainNodes[0],
+      mainNodes[1],
+      mainNodes[2],
+      mainNodes[3],
+      centerNode,     // 中央に配置
+      mainNodes[4],
+      mainNodes[5],
+      mainNodes[6],
+      mainNodes[7],
+    ];
+    
+    return positionedNodes;
+  }, [currentMandala, mandalaNodes]);
 
   const handleCreateNewMandala = async () => {
     if (!newTopic || isLoading) return;
     
     setIsLoading(true);
     try {
-      const topics = await generateMandalaContent(newTopic);
-      
-      // 中心��ードを作成
-      const newNodeId = `mandala-${Date.now()}`;
-      const centerNode = {
-        id: newNodeId,
-        label: newTopic,
-        parentId: undefined,
-        isCenter: true,
-        children: [],
-        position: { x: 0, y: 0 }
-      };
-      
-      addNode(centerNode);
-      setCurrentMandalaId(newNodeId);
-
-      // サブトピックを追加
-      topics.forEach((topic: string, index: number) => {
-        addNode({
-          id: `${newNodeId}-${index}`,
-          label: topic,
-          parentId: newNodeId,
-          isCenter: false,
-          children: [],
-          position: { x: 0, y: 0 }
-        });
-      });
-
-      setNewTopic(''); // 入力をクリア
+      await generateMandalaChart(newTopic);
+      setNewTopic('');
     } catch (error) {
       console.error('Failed to generate mandala:', error);
     } finally {
@@ -107,26 +69,31 @@ export const MandalaChart: React.FC = () => {
     }
   };
 
-  // relatedNodesの取得を修正
-  const relatedNodes = useMemo(() => {
-    if (!currentMandala) return [];
+  const renderCell = (node: MandalaNode | undefined, index: number, parentNode?: MandalaNode) => {
+    const isCenter = index === 4;
     
-    // 中心ノードを取得
-    const centerNode = currentMandala;
-    
-    // 子ノード（8つの要素）を取得
-    const childNodes = mandalaNodes.filter(node => node.parentId === centerNode.id);
-    
-    // 中心ノードと子ノードを結合
-    return [centerNode, ...childNodes];
-  }, [currentMandala, mandalaNodes]);
+    return (
+      <div
+        key={`${parentNode?.id || 'root'}-${index}`}
+        className={`
+          w-[90px] h-[90px] flex items-center justify-center text-white text-center p-2
+          ${isCenter ? 'bg-blue-800' : 'bg-gray-800'}
+          transition-colors duration-200 text-[11px] border border-gray-900
+        `}
+        title={node?.label}
+      >
+        <span className="break-words leading-tight">
+          {node?.label || '...'}
+        </span>
+      </div>
+    );
+  };
 
-  const renderGrid = (node: MandalaNode) => {
+  const renderGrid = (node: MandalaNode | undefined, idx: number) => {
     if (!node) return null;
 
-    // 子ノードを取得（parentIdで紐付いているノードを探す）
+    // 子ノードを取得して3x3グリッドを構成
     const childNodes = mandalaNodes.filter(n => n.parentId === node.id);
-
     const gridElements = Array.from({ length: 9 }, (_, index) => {
       if (index === 4) {
         return node;
@@ -136,37 +103,27 @@ export const MandalaChart: React.FC = () => {
       }
     });
 
-    const position = node.position || { x: 0, y: 0 };
-    const gridStyle = {
-      transform: `translate(${position.x}px, ${position.y}px)`,
-      position: 'absolute' as const,
-      left: '50%',
-      top: '50%',
-      marginLeft: `-${GRID_SIZE / 2}px`,
-      marginTop: `-${GRID_SIZE / 2}px`,
-    };
+    // 行と列の位置を計算
+    const row = Math.floor(idx / 3);
+    const col = idx % 3;
+    const SUB_GRID_SIZE = CELL_SIZE * 3;
+
+    // 位置の計算
+    const top = row * SUB_GRID_SIZE;
+    const left = col * SUB_GRID_SIZE;
 
     return (
       <div
         key={node.id}
-        className="grid grid-cols-3 bg-gray-900"
-        style={gridStyle}
+        className="grid grid-cols-3 bg-gray-900 absolute"
+        style={{
+          width: `${SUB_GRID_SIZE}px`,
+          height: `${SUB_GRID_SIZE}px`,
+          top: `${top}px`,
+          left: `${left}px`,
+        }}
       >
-        {gridElements.map((element, index) => {
-          const isCenter = index === 4;
-          return (
-            <div
-              key={`${node.id}-${index}`}
-              className={`
-                w-[60px] h-[60px] flex items-center justify-center text-white text-center p-2
-                ${isCenter ? 'bg-blue-800' : 'bg-gray-800'}
-                transition-colors duration-200 text-xs border border-gray-900
-              `}
-            >
-              {element?.label || '...'}
-            </div>
-          );
-        })}
+        {gridElements.map((element, i) => renderCell(element, i, node))}
       </div>
     );
   };
@@ -190,7 +147,7 @@ export const MandalaChart: React.FC = () => {
           <button
             onClick={handleCreateNewMandala}
             disabled={isLoading || !newTopic}
-            className="px-4 py-2 bg-blue-600 rounded hover:bg-blue-700 disabled:bg-gray-600 disabled:cursor-not-allowed"
+            className="px-4 py-2 bg-blue-600 rounded hover:bg-blue-700 disabled:bg-gray-600 disabled:cursor-not-allowed text-white"
           >
             {isLoading ? '生成中...' : '作成'}
           </button>
@@ -204,28 +161,22 @@ export const MandalaChart: React.FC = () => {
     <div 
       ref={containerRef}
       className="w-full h-full relative bg-black overflow-auto"
-      style={{ height: 'calc(100vh - 80px)' }}
+      style={{ 
+        height: 'calc(100vh - 80px)',
+        padding: '40px 0'
+      }}
     >
-      <div className="absolute top-4 right-4 z-10">
-        <button 
-          onClick={handleGenerateTopics}
-          disabled={isLoading || !currentMandala}
-          className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:bg-gray-400"
-        >
-          {isLoading ? '生成中...' : 'AIでアイデア生成'}
-        </button>
-      </div>
       <div 
-        className="absolute inset-0 flex items-center justify-center"
+        className="absolute inset-0 flex items-center justify-center min-h-full"
       >
         <div 
           className="relative"
           style={{ 
-            width: '900px',
-            height: '900px'
+            width: `${GRID_SIZE}px`,
+            height: `${GRID_SIZE}px`
           }}
         >
-          {relatedNodes.map((chart) => renderGrid(chart))}
+          {relatedNodes.map((node, idx) => renderGrid(node, idx))}
         </div>
       </div>
     </div>

--- a/src/components/MandalaTest.tsx
+++ b/src/components/MandalaTest.tsx
@@ -1,0 +1,38 @@
+import { useEffect } from 'react';
+import { generateMandalaContent } from '../utils/mandalaOpenai';
+
+export const MandalaTest = () => {
+  useEffect(() => {
+    const testMandalaGeneration = async () => {
+      console.log('マンダラチャート生成テストを開始します...');
+
+      const testTopics: string[] = [
+        'プログラミング学習',
+        'ビジネス成長',
+        '健康管理'
+      ];
+
+      for (const topic of testTopics) {
+        console.log(`\n中心テーマ: ${topic}`);
+        try {
+          const elements = await generateMandalaContent(topic);
+          console.log('生成された要素:');
+          elements.forEach((element: string, index: number) => {
+            console.log(`${index + 1}. ${element}`);
+          });
+        } catch (error) {
+          console.error(`エラー (${topic}):`, error);
+        }
+      }
+    };
+
+    testMandalaGeneration();
+  }, []);
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">マンダラチャートテスト</h1>
+      <p>コンソールを確認してください。</p>
+    </div>
+  );
+};

--- a/src/store/useMandalaStore.ts
+++ b/src/store/useMandalaStore.ts
@@ -42,6 +42,8 @@ type MandalaState = MandalaStoredState & {
     position?: Position
   ) => void;
   initializeMandala: () => void;
+  addNode: (node: MandalaNode) => void;
+  updateNode: (node: MandalaNode) => void;
 };
 
 export const useMandalaStore = create<MandalaState>((set) => ({
@@ -108,4 +110,16 @@ export const useMandalaStore = create<MandalaState>((set) => ({
       return newState;
     });
   },
+
+  addNode: (node) =>
+    set((state) => ({
+      mandalaNodes: [...state.mandalaNodes, node],
+    })),
+
+  updateNode: (updatedNode) =>
+    set((state) => ({
+      mandalaNodes: state.mandalaNodes.map((node) =>
+        node.id === updatedNode.id ? updatedNode : node
+      ),
+    })),
 }));

--- a/src/store/useMandalaStore.ts
+++ b/src/store/useMandalaStore.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
-import { MandalaNode, Position } from "../types";
+import { MandalaNode } from "../types";
 import { generateMandalaNode } from "../utils/mandala";
+import { generateMandalaContent } from "../utils/mandalaOpenai";
 
 const MANDALA_STORAGE_KEY = "miraiMandalaData";
 const GRID_SIZE = 180; // 3 * 60 (CELL_SIZE)
@@ -36,14 +37,34 @@ const saveToLocalStorage = (state: MandalaStoredState) => {
 
 type MandalaState = MandalaStoredState & {
   setCurrentMandalaId: (id: string | null) => void;
-  generateMandalaChart: (
-    label: string,
-    parentId?: string,
-    position?: Position
-  ) => void;
+  generateMandalaChart: (label: string) => Promise<void>;
   initializeMandala: () => void;
   addNode: (node: MandalaNode) => void;
   updateNode: (node: MandalaNode) => void;
+};
+
+const positions = [
+  { x: -GRID_SIZE, y: -GRID_SIZE }, // 左上
+  { x: 0, y: -GRID_SIZE }, // 上
+  { x: GRID_SIZE, y: -GRID_SIZE }, // 右上
+  { x: -GRID_SIZE, y: 0 }, // 左
+  { x: GRID_SIZE, y: 0 }, // 右
+  { x: -GRID_SIZE, y: GRID_SIZE }, // 左下
+  { x: 0, y: GRID_SIZE }, // 下
+  { x: GRID_SIZE, y: GRID_SIZE }, // 右下
+];
+
+const calculateSubPosition = (
+  basePosition: { x: number; y: number },
+  index: number
+) => {
+  const subGridSize = GRID_SIZE / 3;
+  const row = Math.floor(index / 3);
+  const col = index % 3;
+  return {
+    x: basePosition.x + (col - 1) * subGridSize,
+    y: basePosition.y + (row - 1) * subGridSize,
+  };
 };
 
 export const useMandalaStore = create<MandalaState>((set) => ({
@@ -68,55 +89,90 @@ export const useMandalaStore = create<MandalaState>((set) => ({
     });
   },
 
-  generateMandalaChart: (label: string, parentId?: string) => {
-    set((state) => {
+  generateMandalaChart: async (label: string) => {
+    try {
+      // 中心ノードを生成
       const centerNode = generateMandalaNode(
         label,
-        parentId,
+        undefined,
         { x: 0, y: 0 },
         true
       );
+      console.log("中心ノードを生成:", centerNode.label);
 
-      const positions = [
-        { x: -GRID_SIZE, y: -GRID_SIZE }, // 左上
-        { x: 0, y: -GRID_SIZE }, // 上
-        { x: GRID_SIZE, y: -GRID_SIZE }, // 右上
-        { x: -GRID_SIZE, y: 0 }, // 左
-        { x: GRID_SIZE, y: 0 }, // 右
-        { x: -GRID_SIZE, y: GRID_SIZE }, // 左下
-        { x: 0, y: GRID_SIZE }, // 下
-        { x: GRID_SIZE, y: GRID_SIZE }, // 右下
-      ];
+      // 第1階層の8要素を生成
+      const firstLevelElements = await generateMandalaContent(label);
+      console.log("第1階層の要素を生成:", firstLevelElements);
 
-      const surroundingNodes =
-        centerNode.children
-          ?.map((child, index) => {
-            if (!child || index >= positions.length) return null;
+      // 第1階層のノードを生成
+      const firstLevelNodes = firstLevelElements.map(
+        (element: string, index: number) =>
+          generateMandalaNode(element, centerNode.id, positions[index], false)
+      );
+      console.log(
+        "第1階層のノードを生成:",
+        firstLevelNodes.map((node: MandalaNode) => node.label)
+      );
 
+      // 第2階層の要素を並列生成
+      const secondLevelPromises = firstLevelElements.map(
+        async (topic: string) => {
+          console.log("第2階層を生成中:", topic);
+          return generateMandalaContent(topic);
+        }
+      );
+
+      const secondLevelResults = await Promise.all(secondLevelPromises);
+      console.log("第2階層の生成完了");
+
+      // 第2階層のノードを生成
+      const secondLevelNodes = firstLevelNodes.flatMap(
+        (firstLevelNode: MandalaNode, firstIndex: number) => {
+          const subElements = secondLevelResults[firstIndex];
+          console.log(`${firstLevelNode.label}の子ノードを生成:`, subElements);
+
+          return subElements.map((element: string, secondIndex: number) => {
+            const subPosition = calculateSubPosition(
+              positions[firstIndex],
+              secondIndex
+            );
             return generateMandalaNode(
-              child.label,
-              centerNode.id,
-              positions[index],
+              element,
+              firstLevelNode.id,
+              subPosition,
               false
             );
-          })
-          .filter((node): node is MandalaNode => node !== null) || [];
+          });
+        }
+      );
 
-      const newState = {
-        mandalaNodes: [...state.mandalaNodes, centerNode, ...surroundingNodes],
-        currentMandalaId: centerNode.id,
-      };
-      saveToLocalStorage(newState);
-      return newState;
-    });
+      console.log(
+        "生成完了 - 合計ノード数:",
+        1 + firstLevelNodes.length + secondLevelNodes.length
+      );
+
+      // 全ノードを保存
+      set((state) => {
+        const newNodes = [centerNode, ...firstLevelNodes, ...secondLevelNodes];
+
+        const newState = {
+          mandalaNodes: [...state.mandalaNodes, ...newNodes],
+          currentMandalaId: centerNode.id,
+        };
+        saveToLocalStorage(newState);
+        return newState;
+      });
+    } catch (error) {
+      console.error("マンダラチャートの生成に失敗:", error);
+    }
   },
 
-  addNode: (node) =>
+  addNode: (node: MandalaNode) =>
     set((state) => ({
       mandalaNodes: [...state.mandalaNodes, node],
     })),
 
-  updateNode: (updatedNode) =>
+  updateNode: (updatedNode: MandalaNode) =>
     set((state) => ({
       mandalaNodes: state.mandalaNodes.map((node) =>
         node.id === updatedNode.id ? updatedNode : node

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,8 @@
+import { SimulationNodeDatum } from "d3";
+
 export type ViewMode = "neural" | "mandala";
 
-export interface Node {
+export interface Node extends SimulationNodeDatum {
   id: string;
   type: "default";
   position: { x: number; y: number };
@@ -8,12 +10,18 @@ export interface Node {
     label: string;
     nodeType: "user" | "suggestion";
   };
+  // D3.js simulation properties
+  fx?: number | null;
+  fy?: number | null;
+  vx?: number;
+  vy?: number;
+  index?: number;
 }
 
 export interface Edge {
   id: string;
-  source: string;
-  target: string;
+  source: string | Node;
+  target: string | Node;
 }
 
 export interface Position {

--- a/src/utils/mandala.ts
+++ b/src/utils/mandala.ts
@@ -22,10 +22,9 @@ export const calculateNewGridPosition = (
   basePosition: Position = { x: 0, y: 0 }
 ): Position => {
   const { x: relX, y: relY } = calculateGridPosition(clickedIndex);
-  const cellSize = 80; // 1マスのサイズ
-  const gridSize = cellSize * 3; // 3x3グリッド全体のサイズ
+  const cellSize = 100; // グリッド間のスペースを考慮して調整
+  const gridSize = cellSize * 3;
 
-  // クリックされたマスの方向にピッタリくっつけて配置
   return {
     x: basePosition.x + relX * gridSize,
     y: basePosition.y + relY * gridSize,

--- a/src/utils/mandalaOpenai.ts
+++ b/src/utils/mandalaOpenai.ts
@@ -68,3 +68,37 @@ export const generateMandalaContent = async (centerTopic: string) => {
     ];
   }
 };
+
+// 複数の要素に対して並列でマンダラチャートを生成
+export const generateSecondLevelMandala = async (topics: string[]) => {
+  try {
+    // 並列処理で各トピックの8要素を生成
+    const promises = topics.map((topic) => generateMandalaContent(topic));
+    const results = await Promise.all(promises);
+
+    // 結果を整形
+    const secondLevelMap: { [key: string]: string[] } = {};
+    topics.forEach((topic, index) => {
+      secondLevelMap[topic] = results[index];
+    });
+
+    return secondLevelMap;
+  } catch (error) {
+    console.error("Failed to generate second level mandala:", error);
+    // エラー時は各トピックに対してフォールバックを返す
+    const fallbackMap: { [key: string]: string[] } = {};
+    topics.forEach((topic) => {
+      fallbackMap[topic] = [
+        `${topic}の計画`,
+        `${topic}の準備`,
+        `${topic}の実践`,
+        `${topic}の評価`,
+        `${topic}の改善`,
+        `${topic}の継続`,
+        `${topic}の発展`,
+        `${topic}の共有`,
+      ];
+    });
+    return fallbackMap;
+  }
+};

--- a/src/utils/mandalaOpenai.ts
+++ b/src/utils/mandalaOpenai.ts
@@ -1,0 +1,70 @@
+import { openai } from "./openaiConfig";
+
+export const generateMandalaContent = async (centerTopic: string) => {
+  try {
+    console.log("generateMandalaContent: ", centerTopic);
+
+    const response = await openai.chat.completions.create({
+      model: "gpt-3.5-turbo",
+      messages: [
+        {
+          role: "system",
+          content: `
+あなたはマンダラチャートを生成するアシスタントです。
+中心テーマに対して、それを実現するための8つの具体的な要素を提案してください。
+以下の条件を満たすように生成してください：
+
+1. 具体的で実行可能な内容
+2. 中心テーマの目標達成に直接関連する内容
+3. 相互に重複しない独立した内容
+4. 簡潔な表現（1-3単語程度）
+
+結果は以下のようなJSON形式で返してください：
+{
+  "elements": [
+    "要素1",
+    "要素2",
+    "要素3",
+    "要素4",
+    "要素5",
+    "要素6",
+    "要素7",
+    "要素8"
+  ]
+}`,
+        },
+        {
+          role: "user",
+          content: `中心テーマ「${centerTopic}」に関連する8つの要素を生成してください。`,
+        },
+      ],
+      temperature: 0.7,
+      response_format: { type: "json_object" },
+    });
+
+    const content = response.choices[0].message.content;
+    if (!content) {
+      throw new Error("No content received from OpenAI");
+    }
+
+    const parsed = JSON.parse(content);
+    if (!Array.isArray(parsed.elements) || parsed.elements.length !== 8) {
+      throw new Error("Invalid response format");
+    }
+
+    return parsed.elements;
+  } catch (error) {
+    console.error("OpenAI API error:", error);
+    // エラー時のフォールバック
+    return [
+      `${centerTopic}の計画`,
+      `${centerTopic}の準備`,
+      `${centerTopic}の実践`,
+      `${centerTopic}の評価`,
+      `${centerTopic}の改善`,
+      `${centerTopic}の継続`,
+      `${centerTopic}の発展`,
+      `${centerTopic}の共有`,
+    ];
+  }
+};

--- a/src/utils/mandalaTest.ts
+++ b/src/utils/mandalaTest.ts
@@ -1,0 +1,26 @@
+import { generateMandalaContent } from "./mandalaOpenai";
+
+async function testMandalaGeneration(): Promise<void> {
+  console.log("マンダラチャート生成テストを開始します...");
+
+  const testTopics: string[] = [
+    "プログラミング学習",
+    "ビジネス成長",
+    "健康管理",
+  ];
+
+  for (const topic of testTopics) {
+    console.log(`\n中心テーマ: ${topic}`);
+    try {
+      const elements = await generateMandalaContent(topic);
+      console.log("生成された要素:");
+      elements.forEach((element: string, index: number) => {
+        console.log(`${index + 1}. ${element}`);
+      });
+    } catch (error) {
+      console.error(`エラー (${topic}):`, error);
+    }
+  }
+}
+
+testMandalaGeneration();

--- a/src/utils/openai.ts
+++ b/src/utils/openai.ts
@@ -1,0 +1,70 @@
+import { openai } from "./openaiConfig";
+
+const systemPrompt = `
+あなたは未来の行動をサジェストするAIアシスタントです。
+ユーザーの行動に対して、具体的で実行可能な次のアクションを5つ提案してください。
+提案は以下の条件を満たす必要があります：
+
+1. 具体的で実行可能であること
+2. ポジティブな表現を使用すること
+3. 短く簡潔な表現であること（30文字以内）
+4. 必ず「！」で終わること
+
+レスポンスは以下のようなJSON形式で返してください：
+{
+  "suggestions": [
+    "提案1！",
+    "提案2！",
+    "提案3！",
+    "提案4！",
+    "提案5！"
+  ]
+}
+`;
+
+export const generateAISuggestions = async (
+  action: string
+): Promise<string[]> => {
+  console.log("generateAISuggestions called with:", action);
+  console.log("OpenAI API Key:", !!import.meta.env.VITE_OPENAI_API_KEY);
+
+  try {
+    const completion = await openai.chat.completions.create({
+      messages: [
+        { role: "system", content: systemPrompt },
+        { role: "user", content: action },
+      ],
+      model: "gpt-3.5-turbo",
+      temperature: 0.7,
+      max_tokens: 200,
+      response_format: { type: "json_object" },
+    });
+
+    const content = completion.choices[0]?.message?.content;
+    if (!content) {
+      throw new Error("No content received from OpenAI");
+    }
+
+    console.log("OpenAI Response:", content);
+
+    try {
+      const parsed = JSON.parse(content);
+      if (Array.isArray(parsed.suggestions) && parsed.suggestions.length > 0) {
+        return parsed.suggestions.slice(0, 5);
+      }
+      throw new Error("Invalid response format");
+    } catch (parseError) {
+      console.error("Failed to parse OpenAI response:", parseError);
+      throw parseError;
+    }
+  } catch (error) {
+    console.error("OpenAI API Error:", error);
+    return [
+      `${action}を継続的に実践しよう！`,
+      `${action}の質を向上させよう！`,
+      `${action}を記録していこう！`,
+      `${action}を習慣化しよう！`,
+      `${action}を楽しもう！`,
+    ];
+  }
+};

--- a/src/utils/openaiConfig.ts
+++ b/src/utils/openaiConfig.ts
@@ -1,0 +1,6 @@
+import OpenAI from "openai";
+
+export const openai = new OpenAI({
+  apiKey: import.meta.env.VITE_OPENAI_API_KEY,
+  dangerouslyAllowBrowser: true,
+});

--- a/src/utils/suggestions.ts
+++ b/src/utils/suggestions.ts
@@ -1,20 +1,10 @@
 import { Node } from "../types";
+import { generateAISuggestions } from "./openai";
 
-export const generateSuggestions = (action: string): string[] => {
-  const baseTemplates = [
-    `${action}を毎日続けよう！`,
-    `${action}の回数を5回増やそう！`,
-    `${action}の質を高めてみよう！`,
-    `友達と一緒に${action}してみよう！`,
-    `${action}の記録をつけてみよう！`,
-    `${action}のやり方を工夫してみよう！`,
-    `${action}を習慣化しよう！`,
-    `${action}の目標を設定しよう！`,
-    `${action}を楽しむ方法を見つけよう！`,
-    `${action}の効果を確認しよう！`,
-  ];
-
-  return [...baseTemplates].sort(() => Math.random() - 0.5).slice(0, 5);
+export const generateSuggestions = async (
+  action: string
+): Promise<string[]> => {
+  return await generateAISuggestions(action);
 };
 
 const getNodeDistance = (node: Node): number => {


### PR DESCRIPTION
## 変更内容
- マンダラチャートのグリッドサイズを3x3から9x9に拡張
- OpenAIを使用したコンテンツ生成機能を実装
- グリッドの配置ロジックを改善
- レイアウト構造を最適化

## 技術的な変更点
### UI/レイアウト
- GRID_SIZEを270pxから810pxに変更
- renderGrid関数を絶対位置配置方式に変更
- サブグリッドの位置計算ロジックを追加

### データ構造
- relatedNodesの取得ロジックを9x9グリッド用に修正
- 階層構造を3レベルに拡張（中心 → 8つの主要カテゴリー → 各カテゴリーの8つの要素）

### OpenAI統合
- GPT-3.5-turboを使用したコンテンツ生成機能を実装
- エラー時のフォールバック処理を追加
- 並列処理による効率的なコンテンツ生成

## 動作確認項目
- [ ] 9x9のグリッドが正しく表示される
- [ ] 中央ノードが正しい位置に配置される
- [ ] 8つの主要カテゴリーノードが適切に配置される
- [ ] 各サブグリッドの子ノードが正しく表示される
- [ ] OpenAIによるコンテンツ生成が正常に機能する
- [ ] エラー時のフォールバック処理が正しく動作する

## 関連Issue
Closes #[Issue番号]